### PR TITLE
Add ALPN & HTTP Versions to HA Proxy Configuration

### DIFF
--- a/conf/haproxy.cfg
+++ b/conf/haproxy.cfg
@@ -50,6 +50,5 @@ backend www
     # www is the name of the container HTTP
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
     
-
     ################### IMPORTANT ##################################################
     # [SERVERS] DO NOT REMOVE OR EDIT THIS LINE, DO NOT ADD COMMANDS AFTER THIS LINE

--- a/conf/haproxy.cfg
+++ b/conf/haproxy.cfg
@@ -48,7 +48,11 @@ frontend https
 
 backend www
     # www is the name of the container HTTP
+    http-request set-header Host {domain}
+    option forwardfor
+    http-request set-header X-Forwarded-For %[src]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
+   
 
     ################### IMPORTANT ##################################################
     # [SERVERS] DO NOT REMOVE OR EDIT THIS LINE, DO NOT ADD COMMANDS AFTER THIS LINE

--- a/conf/haproxy.cfg
+++ b/conf/haproxy.cfg
@@ -52,3 +52,4 @@ backend www
 
     ################### IMPORTANT ##################################################
     # [SERVERS] DO NOT REMOVE OR EDIT THIS LINE, DO NOT ADD COMMANDS AFTER THIS LINE
+    

--- a/conf/haproxy.cfg
+++ b/conf/haproxy.cfg
@@ -12,7 +12,7 @@ global
     lua-load /etc/haproxy/acme-http01-webroot.lua
     #
     # SSL options
-    ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;
+    ssl-default-bind-ciphers AES256+EECDH:AES256+EDH:!aNULL;
     tune.ssl.default-dh-param 4096
 
     # workaround for bug #14 (Cert renewal blocks HAProxy indefinitely with Websocket connections)
@@ -49,8 +49,7 @@ frontend https
 backend www
     # www is the name of the container HTTP
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-   
+    
 
     ################### IMPORTANT ##################################################
     # [SERVERS] DO NOT REMOVE OR EDIT THIS LINE, DO NOT ADD COMMANDS AFTER THIS LINE
-    

--- a/conf/haproxy.cfg
+++ b/conf/haproxy.cfg
@@ -48,9 +48,6 @@ frontend https
 
 backend www
     # www is the name of the container HTTP
-    http-request set-header Host {$DOMAIN}
-    option forwardfor
-    http-request set-header X-Forwarded-For %[src]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
    
 

--- a/conf/haproxy.cfg
+++ b/conf/haproxy.cfg
@@ -48,7 +48,7 @@ frontend https
 
 backend www
     # www is the name of the container HTTP
-    http-request set-header Host {domain}
+    http-request set-header Host {$DOMAIN}
     option forwardfor
     http-request set-header X-Forwarded-For %[src]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }

--- a/conf/haproxy.cfg
+++ b/conf/haproxy.cfg
@@ -12,7 +12,7 @@ global
     lua-load /etc/haproxy/acme-http01-webroot.lua
     #
     # SSL options
-    ssl-default-bind-ciphers AES256+EECDH:AES256+EDH:!aNULL;
+    ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS;
     tune.ssl.default-dh-param 4096
 
     # workaround for bug #14 (Cert renewal blocks HAProxy indefinitely with Websocket connections)

--- a/conf/haproxy.cfg
+++ b/conf/haproxy.cfg
@@ -49,6 +49,6 @@ frontend https
 backend www
     # www is the name of the container HTTP
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    
+
     ################### IMPORTANT ##################################################
     # [SERVERS] DO NOT REMOVE OR EDIT THIS LINE, DO NOT ADD COMMANDS AFTER THIS LINE

--- a/conf/haproxy.cfg
+++ b/conf/haproxy.cfg
@@ -42,7 +42,7 @@ frontend http
     redirect scheme https code 301 if !{ ssl_fc }
 
 frontend https
-    bind *:443 ssl crt /etc/haproxy/certs/ no-sslv3 no-tls-tickets no-tlsv10 no-tlsv11
+    bind *:443 ssl crt /etc/haproxy/certs/ no-sslv3 no-tls-tickets no-tlsv10 no-tlsv11 alpn h3,h2,http/1.1
     http-response set-header Strict-Transport-Security "max-age=16000000; includeSubDomains; preload;"
     default_backend www
 


### PR DESCRIPTION
This enables the TLS ALPN extension and advertises the specified protocol
list as supported on top of ALPN.

http://docs.haproxy.org/2.6/configuration.html#5.1-alpn